### PR TITLE
feat(stripe): refactor Stripe payment logic into service class

### DIFF
--- a/app/Http/Controllers/StripeController.php
+++ b/app/Http/Controllers/StripeController.php
@@ -2,19 +2,18 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Product;
+use App\Services\StripePaymentService;
 use Exception;
 use Illuminate\Http\Request;
-use Stripe\StripeClient;
+use Illuminate\Support\Facades\Log;
 
 class StripeController extends Controller
 {
-    public $stripe;
-    public function __construct()
+    protected $stripeService;
+
+    public function __construct(StripePaymentService $stripeService)
     {
-        $this->stripe = new StripeClient(
-            config('stripe.api_key.secret')
-        );
+        $this->stripeService = $stripeService;
     }
 
     public function pay(Request $request)
@@ -24,43 +23,46 @@ class StripeController extends Controller
             'products.*.id' => 'required|integer|exists:products,id',
             'products.*.quantity' => 'required|integer|min:1',
         ]);
-        $lineItems = [];
-        foreach ($validated['products'] as $item) {
-            $product = Product::find($item['id']);
-            $lineItems[] = [
-                'price_data' => [
-                    'currency' => 'EGP',
-                    'product_data' => [
-                        'name' => $product->name,
-                    ],
-                    'unit_amount' => $product->price * 100,
-                ],
-                'quantity' => $item['quantity'],
-            ];
-        }
+
         try {
-            $user = auth()->user();
-            if (!$user) {
-                return response()->json(['error' => 'User not authenticated'], 401);
-            }
-            $session = $this->stripe->checkout->sessions->create([
-                'line_items' => $lineItems,
-                'mode' => 'payment',
-                'customer_email' => $user->email,
-                'success_url' => config('stripe.frontend_url') . '/payment-success?session_id={CHECKOUT_SESSION_ID}',
-                'cancel_url' => config('stripe.frontend_url') . '/?canceled=true',
-                'metadata' => [
-                    'user_id' => auth()->id(),
-                ],
-            ]);
-            return response()->json([
-                'id' => $session->id,
-                'url' => $session->url,
-            ], 201);
+            $result = $this->stripeService->createCheckoutSession($validated, auth()->user());
+
+            return response()->json($result, 201);
         } catch (Exception $e) {
+            return response()->json(['error' => 'Payment failed: ' . $e->getMessage()], 500);
+        }
+    }
+
+    public function paymentSuccess(Request $request)
+    {
+        $validated = $request->validate([
+            'session_id' => 'required|string',
+        ]);
+
+        try {
+            $order = $this->stripeService->handlePaymentSuccess($validated['session_id']);
+
             return response()->json([
-                'error' => 'Unexpected error: ' . $e->getMessage(),
-            ], 500);
+                'message' => 'Payment confirmed successfully and cart emptied',
+                'order' => $order,
+            ]);
+        } catch (Exception $e) {
+            return response()->json(['error' => 'Error confirming payment: ' . $e->getMessage()], 500);
+        }
+    }
+
+    public function paymentCancel(Request $request)
+    {
+        $validated = $request->validate([
+            'session_id' => 'required|string',
+        ]);
+
+        try {
+            $this->stripeService->handlePaymentCancel($validated['session_id']);
+
+            return response()->json(['message' => 'Order cancelled successfully']);
+        } catch (Exception $e) {
+            return response()->json(['error' => 'Error cancelling order: ' . $e->getMessage()], 500);
         }
     }
 }

--- a/app/Services/StripePaymentService.php
+++ b/app/Services/StripePaymentService.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Cart;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\User;
+use Exception;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Stripe\StripeClient;
+
+class StripePaymentService
+{
+    protected $stripe;
+
+    public function __construct()
+    {
+        $this->stripe = new StripeClient(config('stripe.api_key.secret'));
+    }
+
+    /**
+     * Create Stripe checkout session and order (without decrementing stock)
+     */
+    public function createCheckoutSession(array $validated, User $user)
+    {
+        DB::beginTransaction();
+
+        try {
+            $lineItems = [];
+            $totalAmount = 0;
+            $productsData = [];
+
+            foreach ($validated['products'] as $item) {
+                $product = Product::lockForUpdate()->find($item['id']);
+                if (!$product) {
+                    throw new Exception("Product ID {$item['id']} not found.");
+                }
+
+                // Check stck availability but don't decrement yet
+                if ($product->stock < $item['quantity']) {
+                    throw new Exception("Insufficient stock for product: {$product->name}. Available: {$product->stock}, Requested: {$item['quantity']}");
+                }
+
+                $lineItems[] = [
+                    'price_data' => [
+                        'currency' => 'EGP',
+                        'product_data' => ['name' => $product->name],
+                        'unit_amount' => $product->price * 100,
+                    ],
+                    'quantity' => $item['quantity'],
+                ];
+
+                $totalAmount += $product->price * $item['quantity'];
+                $productsData[] = ['product' => $product, 'quantity' => $item['quantity']];
+            }
+
+            $session = $this->stripe->checkout->sessions->create([
+                'line_items' => $lineItems,
+                'mode' => 'payment',
+                'customer_email' => $user->email,
+                'success_url' => config('stripe.frontend_url') . '/payment-success?session_id={CHECKOUT_SESSION_ID}',
+                'cancel_url' => config('stripe.frontend_url') . '/payment-cancel?session_id={CHECKOUT_SESSION_ID}',
+                'metadata' => ['user_id' => $user->user_id],
+                'payment_intent_data' => ['capture_method' => 'automatic'],
+            ]);
+
+            $order = Order::create([
+                'stripe_session_id' => $session->id,
+                'user_id' => $user->user_id,
+                'amount' => $totalAmount,
+                'status' => 'pending',
+            ]);
+
+            foreach ($productsData as $item) {
+                OrderItem::create([
+                    'order_id' => $order->id,
+                    'product_id' => $item['product']->id,
+                    'quantity' => $item['quantity'],
+                    'price' => $item['product']->price,
+                ]);
+            }
+
+            DB::commit();
+
+            return [
+                'id' => $session->id,
+                'url' => $session->url,
+                'order_id' => $order->id,
+            ];
+        } catch (Exception $e) {
+            DB::rollBack();
+            Log::error('Payment creation error', ['error' => $e->getMessage()]);
+            throw $e;
+        }
+    }
+
+    /**
+     * Handle successful payment (decrement stock here)
+     */
+    public function handlePaymentSuccess(string $sessionId)
+    {
+        $session = $this->stripe->checkout->sessions->retrieve($sessionId);
+        $userId = $session->metadata['user_id'] ?? null;
+
+        if (!$userId) {
+            throw new Exception('User authentication information missing');
+        }
+
+        if ($session->payment_status === 'paid') {
+            $order = Order::where('stripe_session_id', $session->id)
+                         ->with('orderItems.product')
+                         ->first();
+
+            if (!$order) {
+                throw new Exception('Order not found for this session');
+            }
+
+            if ($order->status === 'pending') {
+                DB::transaction(function () use ($order, $userId) {
+                    foreach ($order->orderItems as $orderItem) {
+                        $product = $orderItem->product;
+                        
+                        if ($product->stock < $orderItem->quantity) {
+                            throw new Exception("Insufficient stock for product: {$product->name}. Available: {$product->stock}, Required: {$orderItem->quantity}");
+                        }
+                        
+                        $product->stock -= $orderItem->quantity;
+                        $product->save();
+                    }
+
+                    $order->update([
+                        'status' => 'paid',
+                        'user_id' => $userId,
+                    ]);
+
+                    $this->emptyUserCart($userId);
+
+                    Log::info('Payment confirmed and stock updated successfully', [
+                        'user_id' => $userId,
+                        'order_id' => $order->id,
+                        'amount' => $order->amount,
+                    ]);
+                });
+            }
+
+            return $order->fresh();
+        }
+
+        throw new Exception('Payment not completed. Status: ' . $session->payment_status);
+    }
+
+    public function handlePaymentCancel(string $sessionId)
+    {
+        $order = Order::where('stripe_session_id', $sessionId)
+                     ->where('status', 'pending')
+                     ->first();
+
+        if ($order) {
+            $order->update(['status' => 'cancelled']);
+            return true;
+        }
+
+        throw new Exception('Order not found or already processed');
+    }
+
+    /**
+     * Empty cart after payment success
+     */
+    private function emptyUserCart($userId)
+    {
+        $cart = Cart::where('user_id', $userId)->first();
+        if ($cart) {
+            $cart->cartProducts()->delete();
+            Log::info('Cart emptied successfully', ['user_id' => $userId]);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,6 +65,8 @@ Route::middleware(['auth:sanctum', EnsureEmailIsVerified::class])->group(functio
     Route::delete('/cart/{id}', [CartController::class, 'destroy']);
     Route::delete('/cart', [CartController::class, 'clear']);
     Route::post('/products/pay', [StripeController::class, 'pay']);
+    Route::post('/payment/success', [StripeController::class, 'paymentSuccess']);
+    Route::post('/payment/cancel', [StripeController::class, 'paymentCancel']);
     Route::post('/cart/buy-with-points', [CartController::class, 'buyWithPoints']);
 });
 // Materials


### PR DESCRIPTION
- Moved payment logic from StripeController to new StripePaymentService
- Implemented createCheckoutSession with stock validation (without decrementing)
- Added handlePaymentSuccess to update order, decrement stock, and clear cart
- Added handlePaymentCancel to mark orders as cancelled
- Updated StripeController to delegate payment logic to StripePaymentService
- Improved error handling, logging, and transaction safety